### PR TITLE
Hide riskClassifier for Sura and value 9

### DIFF
--- a/src/app/modules/private/documents/modal-edit-document/modal-edit-document.component.html
+++ b/src/app/modules/private/documents/modal-edit-document/modal-edit-document.component.html
@@ -446,7 +446,8 @@
 
             <!-- Campo Clasificación de Riesgo -->
             <div nz-col [nzXs]="24" [nzSm]="24" [nzMd]="24" [nzLg]="24" [nzXl]="24" [nzXXl]="24"
-                *ngIf="isFieldRequiredForDocumentType('riskClassifier')">
+                *ngIf="isFieldRequiredForDocumentType('riskClassifier')
+                    && this.currentDoc?.riskClassifier !== '9'">
                 <nz-form-item nz-row>
                     <nz-form-label class="form-label" nzRequired [nzXs]="24" [nzSm]="24" [nzMd]="24" [nzLg]="24"
                         [nzXl]="24">

--- a/src/app/modules/private/documents/modal-edit-document/modal-edit-document.component.ts
+++ b/src/app/modules/private/documents/modal-edit-document/modal-edit-document.component.ts
@@ -249,7 +249,10 @@ export class ModalEditDocumentComponent implements OnInit {
          nombredocumento: item.nombredocumento,
          receptionDate: this.convertDate(item.receptionDate),
          resolutionOfThePension: item.resolutionOfThePension,
-         riskClassifier: this.sanitizeWithOptions(item.riskClassifier, this.riskClassifierOptions),
+         riskClassifier: this.sanitizeWithOptions(
+           item.riskClassifier,
+           [...this.riskClassifierOptions, '9']
+         ),
          validityStartDate: this.convertDate(item.validityStartDate),
          amountPolicy: this.formUtils.formatCurrency(item.amountPolicy),
          tipodocumento: item.idTypeDocuments,


### PR DESCRIPTION
Se oculta campo de "Clasificación de riesgo" cuando el valor es la nueva opción comodín "9" para certificados básicos en el documento de "Certificación afiliación ARL [SURA]".