### PR TITLE
Update expedition validation in docs to allow december dates

### DIFF
--- a/src/app/modules/private/documents/modal-edit-document/modal-edit-document.component.ts
+++ b/src/app/modules/private/documents/modal-edit-document/modal-edit-document.component.ts
@@ -317,7 +317,8 @@ export class ModalEditDocumentComponent implements OnInit {
     const typeDoc = this.currentDoc;
 
     if (typeDoc.currentYear) {
-      if (selectedDate.getFullYear() !== currentYear || selectedDate > today) {
+      const minDate = new Date(currentYear - 1, 11, 1); // 1 de diciembre
+      if (selectedDate < minDate || selectedDate > today) {
         return { dateExpeditionInvalid: 'Debe ser del año inmediatamente presente.' };
       }
     } else if (typeDoc.lastMonth !== null) {


### PR DESCRIPTION
Se actualiza la validación de fecha de expedición para los documentos para que los documentos que deben ser del presente año admitan desde el 1 de diciembre del año anterior, porque hay documentos que se expiden desde fechas anteriores para el año entrante.